### PR TITLE
fix: v-model error with textfield

### DIFF
--- a/frontend/components/TextField.vue
+++ b/frontend/components/TextField.vue
@@ -29,7 +29,7 @@ export interface Fields
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   field: FieldInfo<any>
   extraRules?: InstanceType<typeof VTextField>["$props"]["rules"]
-  modelValue: string | null
+  modelValue: string | number | null
 }
 
 const props = defineProps<Fields>()

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -65,7 +65,7 @@ onMounted(() => {
         <TextField
           :label="name"
           :placeholder="name"
-          v-model="state.name"
+          v-model="state[name]"
           :field="field"
         />
       </template>

--- a/frontend/pages/index.vue
+++ b/frontend/pages/index.vue
@@ -65,7 +65,7 @@ onMounted(() => {
         <TextField
           :label="name"
           :placeholder="name"
-          v-model="state[name]"
+          v-model="state.name"
           :field="field"
         />
       </template>


### PR DESCRIPTION
# What

The textfield should also accept a `number` primitive type.